### PR TITLE
Fix case sensitive value issues for all records by not forcing to lower

### DIFF
--- a/dme/resource_dme_record.go
+++ b/dme/resource_dme_record.go
@@ -33,9 +33,6 @@ func resourceDMERecord() *schema.Resource {
 			"value": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				StateFunc: func(value interface{}) string {
-					return strings.ToLower(value.(string))
-				},
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,


### PR DESCRIPTION
This PR fixes an issue where case-sensitive records are constantly refreshed (an issue with TXT records, but applies to all other records where internal state and external state are managed separately)