### PR TITLE
Allow empty names in dme_record (#3)

### DIFF
--- a/dme/resource_dme_record.go
+++ b/dme/resource_dme_record.go
@@ -24,7 +24,8 @@ func resourceDMERecord() *schema.Resource {
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "",
 			},
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
@@ -162,10 +163,9 @@ func resourceDMERecordDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getAll(d *schema.ResourceData, cr map[string]interface{}) error {
+	attr := d.Get("name")
+	cr["name"] = attr.(string)
 
-	if attr, ok := d.GetOk("name"); ok {
-		cr["name"] = attr.(string)
-	}
 	if attr, ok := d.GetOk("type"); ok {
 		cr["type"] = attr.(string)
 	}

--- a/dme/resource_dme_record_test.go
+++ b/dme/resource_dme_record_test.go
@@ -44,6 +44,37 @@ func TestAccDMERecord_basic(t *testing.T) {
 	})
 }
 
+func TestAccDMERecord_tld(t *testing.T) {
+	var record dnsmadeeasy.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigA_tld, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", ""),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "1.1.1.2"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "gtdLocation", "DEFAULT"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDMERecordCName(t *testing.T) {
 	var record dnsmadeeasy.Record
 	domainid := os.Getenv("DME_DOMAINID")
@@ -397,6 +428,16 @@ resource "dme_record" "test" {
   name = "testa"
   type = "A"
   value = "1.1.1.1"
+  ttl = 2000
+  gtdLocation = "DEFAULT"
+}`
+
+const testDMERecordConfigA_tld = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = ""
+  type = "A"
+  value = "1.1.1.2"
   ttl = 2000
   gtdLocation = "DEFAULT"
 }`


### PR DESCRIPTION
The fixes Issue #3 and builds upon the existing PR #5.

I've added an acceptance test called `TestAccDMERecord_tld` to confirm this is working as expected.

## Acceptance Test Notes

Some acceptance tests failed for me when I ran the entire suite.
* `TestAccDMERecordTXT`
* `TestAccDMERecordSPF`
* `TestAccDMERecordNS`

These failures occurred before and after my changes.  They seem unrelated and should probably be addressed in a separate PR.