### PR TITLE
Make dme_record importable

### DIFF
--- a/dme/resource_dme_record.go
+++ b/dme/resource_dme_record.go
@@ -15,6 +15,9 @@ func resourceDMERecord() *schema.Resource {
 		Read:   resourceDMERecordRead,
 		Update: resourceDMERecordUpdate,
 		Delete: resourceDMERecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDMERecordImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			// Use recordid for TF ID.
@@ -159,6 +162,21 @@ func resourceDMERecordDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceDMERecordImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	input_id := d.Id()
+
+	parts := strings.SplitN(input_id, "/", 2)
+
+	if len(parts) == 2 {
+		d.Set("domainid", parts[0])
+		d.SetId(parts[1])
+	} else {
+		return nil, fmt.Errorf("Error parsing id, unable to import: %s. Must be in format DOMAIN_ID/RECORD_ID.", input_id)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func getAll(d *schema.ResourceData, cr map[string]interface{}) error {

--- a/dme/resource_dme_record_test.go
+++ b/dme/resource_dme_record_test.go
@@ -391,6 +391,28 @@ func testAccCheckDMERecordExists(n string, record *dnsmadeeasy.Record) resource.
 	}
 }
 
+func TestAccTDMERecord_importBasic(t *testing.T) {
+	resourceName := "dme_record.test"
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testDMERecordConfigA, domainid),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", domainid),
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 const testDMERecordConfigA = `
 resource "dme_record" "test" {
   domainid = "%s"

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -247,3 +247,24 @@ resource "dme_record" "testsrv" {
   ttl      = 1000
 }
 ```
+
+## Import
+
+DNSMadeEasy records can be imported using the domain ID and record ID of the
+record, separated by a "/". e.g.,
+
+```
+$ terraform import dme_record.foo 123123/45674567
+```
+
+In this example, `123123` is the domain ID and `45674567` is the record ID.
+
+The Record ID for a given record can be found using the DNSMadeEasy web control panel.
+
+1. Select the "DNS - Managed DNS" menu once logged into the web control panel
+2. Select a domain name
+3. Double click an A record
+4. Enable the check box for Dynamic DNS (if not already enabled)
+5. You can view the record ID here
+
+Source: https://support.dnsmadeeasy.com/index.php?/Knowledgebase/Article/View/17/2/what-is-my-record-id--ddns-id


### PR DESCRIPTION
This PR makes `dme_record` resources importable.  Below is the documentation I added to the website markdown.

---
## Import

DNSMadeEasy records can be imported using the domain ID and record ID of the
record, separated by a "/". e.g.,

```
$ terraform import dme_record.foo 123123/45674567
```

In this example, `123123` is the domain ID and `45674567` is the record ID.

The Record ID for a given record can be found using the DNSMadeEasy web control panel.

1. Select the "DNS - Managed DNS" menu once logged into the web control panel
2. Select a domain name
3. Double click an A record
4. Enable the check box for Dynamic DNS (if not already enabled)
5. You can view the record ID here

Source: https://support.dnsmadeeasy.com/index.php?/Knowledgebase/Article/View/17/2/what-is-my-record-id--ddns-id