### PR TITLE
Fixes markdown line breaks; clarifies MX level

### DIFF
--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -30,12 +30,14 @@ The following arguments are supported:
 
 * `domainid` - (String, Required) The domain id to add the
   record to
-* `name` - (Required) The name of the record `type` - (Required) The type of
-* the record `value` - (Required) The value of the record; its usage
+* `name` - (Required) The name of the record
+* `type` - (Required) The type of the record
+* `value` - (Required) The value of the record; its usage
   will depend on the `type` (see below)
-* `ttl` - (Integer, Optional) The TTL of the record `gtdLocation` - (String,
-  Optional) The GTD Location of the record on Global Traffic Director enabled
-  domains; Unless GTD is enabled this should either be omitted or set to
+* `ttl` - (Integer, Optional) The TTL of the record
+* `gtdLocation` - (String, Optional) The GTD Location of the
+  record on Global Traffic Director enabled domains - unless
+  GTD is enabled this should either be omitted or set to
   "DEFAULT"
 
 Additional arguments are listed below under DNS Record Types.
@@ -63,7 +65,7 @@ information.
 #### MX Record
 
 * `value` is the server
-* `mxLevel` (Integer, Required) is the MX level
+* `mxLevel` (Integer, Required) is the MX level (aka priority)
 
 ####  HTTPRED Record
 
@@ -117,15 +119,14 @@ The following attributes are exported:
 
 * `name` - The name of the record
 * `type` - The type of the record
-* `value` - The value of the record
-  `type` (see below)
+* `value` - The value of the record `type` (see below)
 * `ttl` - The TTL of the record
 * `gtdLocation` - The GTD Location of the record on GTD enabled domains
 
 Additional fields may also be exported by some record types -
 see DNS Record Types.
 
-#### Record Type Examples
+## Record Type Examples
 
 Following are examples of using each of the record types.
 


### PR DESCRIPTION
At present there's a few line break errors at https://www.terraform.io/docs/providers/dme/r/record.html

This pull request fixes those, as well as clarifying that 'MX level' means MX priority, and promoting the 'Record Type Examples' heading so it isn't a subheading under Attributes Reference.