### PR TITLE
Change docs to note usesandbox var is required

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -40,6 +40,6 @@ The following arguments are supported:
   the `DME_AKEY` shell environment variable.
 * `skey` - (Required) The DNSMadeEasy Secret key. This can also be specified
   with the `DME_SKEY` shell environment variable.
-* `usesandbox` - (Optional) If true, the DNSMadeEasy sandbox will be
+* `usesandbox` - (Required) If true, the DNSMadeEasy sandbox will be
   used. This can also be specified with the `DME_USESANDBOX` shell environment
   variable.


### PR DESCRIPTION
When using the provider without `usesandbox` defined, an error is returned:
```Error: provider.dme: "usesandbox": required field is not set```