### PR TITLE
add read cache for most frequent resources

### DIFF
--- a/dme/cache_dme_dns_records.go
+++ b/dme/cache_dme_dns_records.go
@@ -1,0 +1,32 @@
+package dme
+
+import (
+	"sync"
+
+	"github.com/DNSMadeEasy/dme-go-client/client"
+	"github.com/DNSMadeEasy/dme-go-client/container"
+)
+
+type dnsRecordsCacheType struct {
+	records map[string]*container.Container
+	mutex   sync.Mutex
+}
+
+var dnsRecordsCache = dnsRecordsCacheType{
+	make(map[string]*container.Container),
+	sync.Mutex{},
+}
+
+func (cache *dnsRecordsCacheType) getByDomain(dmeClient *client.Client, domain string) (*container.Container, error) {
+	cache.mutex.Lock()
+	if _, ok := cache.records[domain]; !ok {
+		con, err := dmeClient.GetbyId("dns/managed/" + domain + "/records")
+		if err != nil {
+			cache.mutex.Unlock()
+			return nil, err
+		}
+		cache.records[domain] = con.S("data")
+	}
+	cache.mutex.Unlock()
+	return cache.records[domain], nil
+}

--- a/dme/cache_dme_domain.go
+++ b/dme/cache_dme_domain.go
@@ -1,0 +1,32 @@
+package dme
+
+import (
+	"sync"
+
+	"github.com/DNSMadeEasy/dme-go-client/client"
+	"github.com/DNSMadeEasy/dme-go-client/container"
+)
+
+type domainCacheType struct {
+	domains map[string]*container.Container
+	mutex   sync.Mutex
+}
+
+var domainCache = domainCacheType{
+	make(map[string]*container.Container),
+	sync.Mutex{},
+}
+
+func (cache *domainCacheType) getByDomain(dmeClient *client.Client, domain string) (*container.Container, error) {
+	cache.mutex.Lock()
+	if _, ok := cache.domains[domain]; !ok {
+		con, err := dmeClient.GetbyId("dns/managed/" + domain)
+		if err != nil {
+			cache.mutex.Unlock()
+			return nil, err
+		}
+		cache.domains[domain] = con
+	}
+	cache.mutex.Unlock()
+	return cache.domains[domain], nil
+}

--- a/dme/datasource_dme_dns_records.go
+++ b/dme/datasource_dme_dns_records.go
@@ -143,12 +143,13 @@ func datasourceManagedDNSRecordActionsRead(d *schema.ResourceData, m interface{}
 	name := d.Get("name").(string)
 	recordtype := d.Get("type").(string)
 
-	con, err := dmeClient.GetbyId("dns/managed/" + d.Get("domain_id").(string) + "/records")
+	con, err := dnsRecordsCache.getByDomain(dmeClient, d.Get("domain_id").(string))
 	if err != nil {
 		return err
 	}
 
-	data := con.S("data").Data().([]interface{})
+	data := con.Data().([]interface{})
+
 	var flag bool
 	var count int
 	for _, info := range data {
@@ -163,7 +164,7 @@ func datasourceManagedDNSRecordActionsRead(d *schema.ResourceData, m interface{}
 		return fmt.Errorf("Record of specified name not found")
 	}
 
-	cont1 := con.S("data").Index(count)
+	cont1 := con.Index(count)
 
 	d.SetId(fmt.Sprintf("%v", cont1.S("id").String()))
 	d.Set("name", StripQuotes(cont1.S("name").String()))

--- a/dme/resource_dme_dns_records.go
+++ b/dme/resource_dme_dns_records.go
@@ -249,13 +249,13 @@ func resourceManagedDNSRecordActionsRead(d *schema.ResourceData, m interface{}) 
 	log.Println("andkamdak")
 	dnsId := d.Id()
 	log.Println("Inside read ID value: ", dnsId)
-	con, err := dmeClient.GetbyId("dns/managed/" + d.Get("domain_id").(string) + "/records?recordName=" + d.Get("name").(string) + "&type=" + d.Get("type").(string))
+	con, err := dnsRecordsCache.getByDomain(dmeClient, d.Get("domain_id").(string))
 	if err != nil {
 		return err
 	}
 	log.Println("Inside read method: ", con)
 
-	data := con.S("data").Data().([]interface{})
+	data := con.Data().([]interface{})
 	var count int
 	log.Println("data: ", data)
 
@@ -269,7 +269,7 @@ func resourceManagedDNSRecordActionsRead(d *schema.ResourceData, m interface{}) 
 		count = count + 1
 	}
 
-	cont1 := con.S("data").Index(count)
+	cont1 := con.Index(count)
 
 	d.SetId(fmt.Sprintf("%v", cont1.S("id").String()))
 

--- a/dme/resource_dme_domain.go
+++ b/dme/resource_dme_domain.go
@@ -174,7 +174,7 @@ func resourceDMEDomainRead(d *schema.ResourceData, m interface{}) error {
 	dmeClient := m.(*client.Client)
 	dn := d.Id()
 
-	con, err := dmeClient.GetbyId("dns/managed/" + dn)
+	con, err := domainCache.getByDomain(dmeClient, dn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As my configuration has several domains and records I frequently run into the API call limit.

This API adds a cache for records and domains so that they only need to be read once.

Other resources might be cached with the same technique if required.