### PR TITLE
Use Terraform provider environment variable convention - fixes #19

### DIFF
--- a/dme/provider.go
+++ b/dme/provider.go
@@ -15,14 +15,14 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "API key for HTTP call",
-				DefaultFunc: schema.EnvDefaultFunc("apikey", nil),
+				DefaultFunc: schema.EnvDefaultFunc("DME_API_KEY", nil),
 			},
 
 			"secret_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Secret Key for HMAC",
-				DefaultFunc: schema.EnvDefaultFunc("secretkey", nil),
+				DefaultFunc: schema.EnvDefaultFunc("DME_SECRET_KEY", nil),
 			},
 
 			"insecure": &schema.Schema{


### PR DESCRIPTION
Right now it's awkward that the environment variables aren't capitalized and prefixed. This is the convention I've seen all other providers take and prevents namespace collisions.