### PR TITLE
`dme_domain` resource import

### DIFF
--- a/dme/resource_dme_domain.go
+++ b/dme/resource_dme_domain.go
@@ -16,6 +16,9 @@ func resourceDMEDomain() *schema.Resource {
 		Read:   resourceDMEDomainRead,
 		Update: resourceDMEDomainUpdate,
 		Delete: resourceDMEDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDMEDomainImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -204,4 +207,13 @@ func resourceDMEDomainDelete(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId("")
 	return nil
+}
+
+func resourceDMEDomainImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	err := resourceDMEDomainRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/dme/resource_dme_domain_test.go
+++ b/dme/resource_dme_domain_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccDomain_Basic(t *testing.T) {
+	resourceName := "dme_domain.example"
 	var domain models.DomainAttribute
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,15 +22,21 @@ func TestAccDomain_Basic(t *testing.T) {
 			{
 				Config: testAccCheckDMEDomainConfig_basic("domain_test_basic1.com", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDMEDomainExists("dme_domain.example", &domain),
+					testAccCheckDMEDomainExists(resourceName, &domain),
 					testAccCheckDMEDomainAttributes("domain_test_basic1.com", "false", &domain),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccDMEDomain_Update(t *testing.T) {
+	resourceName := "dme_domain.example"
 	var domain models.DomainAttribute
 
 	resource.Test(t, resource.TestCase{
@@ -40,14 +47,14 @@ func TestAccDMEDomain_Update(t *testing.T) {
 			{
 				Config: testAccCheckDMEDomainConfig_basic("domain_test_update1.com", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDMEDomainExists("dme_domain.example", &domain),
+					testAccCheckDMEDomainExists(resourceName, &domain),
 					testAccCheckDMEDomainAttributes("domain_test_update1.com", "false", &domain),
 				),
 			},
 			{
 				Config: testAccCheckDMEDomainConfig_basic("domain_test_update1.com", "true"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDMEDomainExists("dme_domain.example", &domain),
+					testAccCheckDMEDomainExists(resourceName, &domain),
 					testAccCheckDMEDomainAttributes("domain_test_update1.com", "true", &domain),
 				),
 			},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -41,3 +41,13 @@ was last updated in Epoch time. Not configurable by the user.
 * `created` - The number of seconds since the domain
 was last created in Epoch time. Not configurable by the user.
 * `id` - Set to the dme calculated id of domain action.
+
+## Import
+
+Domain can be imported using the `id`, e.g.
+
+```bash
+$ terraform import dme_domain.example_com 7955579
+```
+
+You can copy `id` from domain index page URL, e.g. https://cp.dnsmadeeasy.com/dns/managed/7955579.


### PR DESCRIPTION
Thanks for developing and maintaining the Terraform provider for DME resources 🙇  I have a bunch of exisitng domains which I'd like to manage with Terraform. This change provides `dme_domain` resource import. I'm going to work on the other resources import capability too. Partially closes #21.

## Test

```
$ export apikey=<REDACTED>
$ export secretkey=<REDACTED>
$ make testacc TESTARGS='-run=TestAccDomain_Basic'
make testacc TESTARGS='-run=TestAccDomain_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDomain_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-dme	[no test files]
=== RUN   TestAccDomain_Basic
    testing.go:745: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: Cannot delete a domain that is pending a create or delete action.

        State: dme_domain.example:
          ID = 7969106
          provider = provider.dme
          created = 1702339200000
          folder_id = 102461
          gtd_enabled = false
          name = domain_test_basic1.com
          soa_id =
          template_id =
          transfer_acl_id =
          updated = 1702407712514
          vanity_id = 26221
--- FAIL: TestAccDomain_Basic (4.35s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-dme/dme	4.767s
FAIL
make: *** [testacc] Error 1
```

The test passes but cleanup can't be handled due to a resource eventual consistency nature. I haven't found a quick way to disabled destroy step in SDK v1 to make test green and sweep resource manually.


## Notes

1. Can you provide some sandbox account to run the tests, please? I've run them in my production account for this contribution but would be glad to have a separate test environment.
1. I'd recommend using the same environment variables in tests as in production provider/client for the sake of less ambiguity or at least adjust the [error message text](https://github.com/DNSMadeEasy/terraform-provider-dme/blob/master/dme/provider_test.go#L35) as it doesn't reveal intention well:
    ```diff
    - apikey
    - secretkey
    + DME_API_KEY
    + DME_SECRET_KEY
    ```
1. SDK v1 is quite old. Are there any plans to upgrade it to [SDK v2](https://developer.hashicorp.com/terraform/plugin/sdkv2) or [Framework](https://developer.hashicorp.com/terraform/plugin/framework)?

