### PR TITLE
Fix/domain optional fields sync issue

### DIFF
--- a/dme/resource_dme_domain.go
+++ b/dme/resource_dme_domain.go
@@ -27,31 +27,32 @@ func resourceDMEDomain() *schema.Resource {
 			"gtd_enabled": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
+				Default:  "false",
 			},
 
 			"soa_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 
 			"template_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 
 			"vanity_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 
 			"transfer_acl_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 
 			"folder_id": &schema.Schema{
@@ -129,25 +130,11 @@ func resourceDMEDomainUpdate(d *schema.ResourceData, m interface{}) error {
 	dmeClient := m.(*client.Client)
 	domainAttr := &models.DomainAttribute{}
 
-	if d.HasChange("gtd_enabled") {
-		domainAttr.GtdEnabled = d.Get("gtd_enabled").(string)
-	}
-
-	if d.HasChange("soa_id") {
-		domainAttr.SOAID = d.Get("soa_id").(string)
-	}
-
-	if d.HasChange("template_id") {
-		domainAttr.TemplateID = d.Get("template_id").(string)
-	}
-
-	if d.HasChange("vanity_id") {
-		domainAttr.VanityID = d.Get("vanity_id").(string)
-	}
-
-	if d.HasChange("transfer_acl_id") {
-		domainAttr.TransferAClID = d.Get("transfer_acl_id").(string)
-	}
+	domainAttr.GtdEnabled = d.Get("gtd_enabled").(string)
+	domainAttr.SOAID = d.Get("soa_id").(string)
+	domainAttr.TemplateID = d.Get("template_id").(string)
+	domainAttr.VanityID = d.Get("vanity_id").(string)
+	domainAttr.TransferAClID = d.Get("transfer_acl_id").(string)
 
 	if d.HasChange("folder_id") {
 		domainAttr.FolderID = d.Get("folder_id").(string)

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -28,12 +28,12 @@ It takes around 10 minutes to reflect the changes on the DNS Made Easy platform.
 
 ## Argument Reference ##
 * `name` - (Required) Name of domain action. Name should be unique.
-* `gtd_enabled` - (Optional) Indicator of whether or not this domain uses the Global Traffic Director service.
-* `soa_id` - (Optional) The ID of a custom SOA record.
-* `template_id` - (Optional) The ID of a template applied to the domain.
-* `vanity_id` - (Optional) The ID of a vanity DNS configuration.
-* `transfer_acl_id` - (Optional) The ID of an applied transfer ACL.
-* `folder_id` - (Optional) The ID of a domain folder.
+* `gtd_enabled` - (Optional) Indicator of whether or not this domain uses the Global Traffic Director service. Default value is `false`.
+* `soa_id` - (Optional) The ID of a custom SOA record. If unused, it does not use any custom SOA record for the domain.
+* `template_id` - (Optional) The ID of a template applied to the domain. If unused, it does not use any template for the domain.
+* `vanity_id` - (Optional) The ID of a vanity DNS configuration. If unused, it does not use any vanity nameservers for the domain.
+* `transfer_acl_id` - (Optional) The ID of an applied transfer ACL. If unused, it does not use any transfer acl for the domain.
+* `folder_id` - (Optional) The ID of a domain folder. If unused, it uses the system created `Default Folder`.
 
 ## Attribute Reference ##
 * `updated` - The number of seconds since the domain


### PR DESCRIPTION
Fixed syncing of the optional fields of the domain resource: 
- Unset `Computed` property of the optional fields, which purely rely on the user's input.
- Always include the used/updated values of these optional fields in the payload for the update request. 
