### PR TITLE
support dns_record resource import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ website/vendor
 .idea
 *.sh
 test/*
+
+secrets.auto.tfvars

--- a/dme/resource_dme_dns_records.go
+++ b/dme/resource_dme_dns_records.go
@@ -9,8 +9,6 @@ import (
 	"github.com/DNSMadeEasy/dme-go-client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	// "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	// "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceManagedDNSRecordActions() *schema.Resource {
@@ -19,6 +17,9 @@ func resourceManagedDNSRecordActions() *schema.Resource {
 		Update: resourceManagedDNSRecordActionsUpdate,
 		Read:   resourceManagedDNSRecordActionsRead,
 		Delete: resourceManagedDNSRecordActionsDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceManagedDNSRecordActionsImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"domain_id": &schema.Schema{
@@ -38,7 +39,6 @@ func resourceManagedDNSRecordActions() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"dynamic_dns": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -152,9 +152,11 @@ func resourceManagedDNSRecordActionsCreate(d *schema.ResourceData, m interface{}
 	recordAttr := models.ManagedDNSRecordActions{}
 
 	recordAttr.Name = d.Get("name").(string)
-	// if name, ok := d.GetOk("name"); ok {
-	// 	recordAttr.Name = name.(string)
-	// }
+
+	// Fix the domain_id check
+	if d.Get("domain_id").(string) == "" {
+		return fmt.Errorf("domain_id is required but not provided")
+	}
 
 	if value, ok := d.GetOk("value"); ok {
 		recordAttr.Value = value.(string)
@@ -224,7 +226,7 @@ func resourceManagedDNSRecordActionsCreate(d *schema.ResourceData, m interface{}
 	}
 	log.Println("Value of recordAttr: ", &recordAttr)
 
-	cont, err := dmeClient.Save(&recordAttr, "dns/managed/"+d.Get("domain_id").(string)+"/records/")
+	cont, err := dmeClient.Save(&recordAttr, "dns/managed/"+d.Get("domain_id").(string)+"/records")
 
 	if err != nil {
 		log.Println("Error returned: ", err)
@@ -405,4 +407,58 @@ func resourceManagedDNSRecordActionsDelete(d *schema.ResourceData, m interface{}
 
 	d.SetId("")
 	return nil
+}
+
+func resourceManagedDNSRecordActionsParseId(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of import (%s), expected domain_id:dns_record_id", id)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func resourceManagedDNSRecordActionsImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	dmeClient := m.(*client.Client)
+
+	// d.Set("domain_id", domain_id)
+	log.Println("Value of domain_id: ", d.Get("domain_id"))
+	// pass in domain_id/id
+	domain_id, id, err := resourceManagedDNSRecordActionsParseId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+	d.Set("domain_id", domain_id)
+	d.SetId(id)
+	// this returns all records, unable to get a single record by id...
+	con, err := dmeClient.GetbyId("dns/managed/" + domain_id + "/records")
+	if err != nil {
+		return nil, err
+	}
+	log.Println("dmeclient get: ", con)
+	data := con.S("data").Data().([]interface{})
+	var foundRecord map[string]interface{}
+	// loop through the results.
+	for _, info := range data {
+		record := info.(map[string]interface{})
+		recordID := fmt.Sprintf("%.0f", record["id"]) // Convert float to string without decimal
+		log.Println("Checking record ID: ", recordID, " against target ID: ", id)
+		if recordID == id {
+			foundRecord = record
+			log.Println("Found matching record: ", foundRecord)
+			break
+		}
+	}
+	if foundRecord == nil {
+		return nil, fmt.Errorf("record with ID %s not found in domain %s", id, domain_id)
+	}
+	// these types are needed by the Read call...
+	d.Set("name", foundRecord["name"].(string))
+	d.Set("type", foundRecord["type"].(string))
+	err = resourceManagedDNSRecordActionsRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/dme/resource_dme_dns_records_test.go
+++ b/dme/resource_dme_dns_records_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccDomainRecords_Basic(t *testing.T) {
 	var record models.ManagedDNSRecordActions
+	dnsRecordTest := "dme_dns_record.a1"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -21,9 +22,19 @@ func TestAccDomainRecords_Basic(t *testing.T) {
 			{
 				Config: testAccCheckDMERecordConfig_basic("86400"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDMERecordExists("dme_domain.domain1", "dme_dns_record.a1", &record),
+					testAccCheckDMERecordExists("dme_domain.domain1", dnsRecordTest, &record),
 					testAccCheckDMERecordAttributes("86400", &record),
 				),
+			},
+			{
+				ResourceName:      dnsRecordTest,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "dme_dns_record.HTTPREDrecord",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -67,6 +78,18 @@ func testAccCheckDMERecordConfig_basic(ttl string) string {
 		ttl = "%s"
 		type = "A"
 		value = "1.2.3.4"
+	}
+	resource "dme_dns_record" "HTTPREDrecord" {
+		domain_id     = "${dme_domain.example.id}"
+		name          = "practice"
+		type          = "HTTPRED"
+		ttl           = "86402"
+		value         = "http://www.facebook.com"
+		description   = "First http record"
+		keywords      = "practice record"
+		title         = "record"
+		redirect_type = "Standard - 302"
+		hardlink      = "true"
 	}
 	`, ttl)
 }

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,85 @@
-provider "dme" {
-  api_key    = ""
-  secret_key = ""
-}
-
-# resource "dme_template_record" "record" {
-#   template_id = "25095"
-#   name = "darsh14"
-#   type = "A"
-#   value = "1.2.3.6"
-#   ttl = "86405"
+## for development: add to your .terraformrc:
+# provider_installation {
+#   dev_overrides {
+#       "dnsmadeeasy.com/provider/dme" = "<PATH>" # usually $HOME/go/bin
+#   }
+#   direct {}
 # }
 
-data "dme_template_record" "first" {
-  template_id = "25095"
-  name = "darsh"
-  type = "A"
+
+terraform {
+  required_providers {
+    dme = {
+      source = "dnsmadeeasy.com/provider/dme"
+    }
+  }
 }
 
-output "demo" {
-  value = "${data.dme_template_record.first}"
+variable "api_key" {
+  description = "API key for DME provider"
+  type        = string
 }
+
+variable "secret_key" {
+  description = "Secret key for DME provider"
+  type        = string
+}
+
+## add a `secrets.auto.tfvars` file with your api secrets. 
+provider "dme" {
+  api_key    = var.api_key
+  secret_key = var.secret_key
+  ## if you want to use the sandbox api, see docs at at https://api-docs.dnsmadeeasy.com/#intro 
+  # base_url = "https://api.sandbox.dnsmadeeasy.com/V2.0" 
+}
+
+resource "dme_domain" "domain1" {
+  name = "domain1.com"
+}
+
+resource "dme_dns_record" "record1" {
+  domain_id     = dme_domain.domain1.id
+  name          = "record1"
+  type          = "A"
+  ttl           = "86400"
+  value         = "10.20.30.40"
+  # description   = "First http record"
+  # keywords      = "practice record"
+  # title         = "record"
+  # redirect_type = "Standard - 302"
+  # hardlink      = "true"
+}
+
+resource "dme_dns_record" "record2" {
+  domain_id     = dme_domain.domain1.id
+  name          = "record2"
+  type          = "A"
+  ttl           = "86400"
+  value         = "10.20.30.50"
+  # description   = "First http record"
+  # keywords      = "practice record"
+  # title         = "record"
+  # redirect_type = "Standard - 302"
+  # hardlink      = "true"
+}
+
+resource "dme_dns_record" "HTTPREDrecord" {
+  domain_id     = "${dme_domain.domain1.id}"
+  name          = "practice"
+  type          = "HTTPRED"
+  ttl           = "86402"
+  value         = "http://www.facebook.com"
+  description   = "First http record"
+  keywords      = "practice record"
+  title         = "record"
+  redirect_type = "Standard - 302"
+  hardlink      = "true"
+}
+
+output "domain1" {
+  value = "${dme_domain.domain1}"
+}
+# output "record1" {
+#   value = dme_dns_record.record1
+# }
 

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # dme_dns_record #
+
 Manages one or more records in a domain within the account.
 
 # Example Usage #
+
 ```hcl
 resource "dme_dns_record" "record" {
   domain_id     = "${dme_domain.example.id}"
@@ -27,21 +29,23 @@ resource "dme_dns_record" "record" {
 ```
 
 ## Argument Reference ##
+
 * `name` - (Required) Name of record.
-* `value` - (Required) Value of record.
-  For A record Ipv4 address is required. For example: value: "1.2.3.4"
-  For CNAME record alias name is required. For example: value: "www"
-  For ANAME record FQDN is required. For example: value: "www.google.com."
-  For MX record server name is required. For example: value: "document."
-  For HTTPRED record URL is required. For example: value: "http://www.google.com"
-  For TXT record text data is required. For example: value: "practice"
-  For SPF record string value is required. For example: value: "1.2.3.4"
-  For PTR record host name is required. For example: value: "mail.domainDocument."
-  For NS record host name is required. For example: value: "mail.domainDocument." 
-  For AAAA record IPv6 address is required. For example: value: "0::0:0:0:0:0:6"
-  For SRV record host name is required. For example: value: "mail.domainDocument."
-  For CAA record text data is required. For example: value: "comodoca.com"
-* `type` - (Required) The record type. Values: A, AAAA, ANAME, CNAME, HTTPRED, MX, NS, PTR, SRV, TXT, CAA or SPF.
+* `domain_id` - (Required) The DME Domain Id the record should be created under.
+* `value` - (Required) Value of the record.
+  * For `A` record Ipv4 address is required. For example: value: "1.2.3.4"
+  * For `CNAME` record alias name is required. For example: value: "www"
+  * For `ANAME` record FQDN is required. For example: value: "www.google.com."
+  * For `MX` record server name is required. For example: value: "document."
+  * For `HTTPRED` record URL is required. For example: value: "http://www.google.com"
+  * For `TXT` record text data is required. For example: value: "practice"
+  * For `SPF` record string value is required. For example: value: "1.2.3.4"
+  * For `PTR` record host name is required. For example: value: "mail.domainDocument."
+  * For `NS` record host name is required. For example: value: "mail.domainDocument." 
+  * For `AAAA` record IPv6 address is required. For example: value: "0::0:0:0:0:0:6"
+  * For `SRV` record host name is required. For example: value: "mail.domainDocument."
+  * For `CAA` record text data is required. For example: value: "comodoca.com"
+* `type` - (Required) The record type. Possible Values: `A`, `AAAA`, `ANAME`, `CNAME`, `HTTPRED`, `MX`, `NS`, `PTR`, `SRV`, `TXT`, `CAA` or `SPF`.
 * `ttl` - (Required) The time to live or TTL of the record.
 * `gtd_location` - (Optional) Global Traffic Director location. Values:DEFAULT, US_EAST, US_WEST, EUROPE, ASIA_PAC, OCREANIA.
 * `dynamic_dns` - (Optional) Indicates if the record has dynamic DNS enabled or not.
@@ -56,7 +60,12 @@ resource "dme_dns_record" "record" {
 * `priority` - (Optional) The priority for an SRV Record. Priority is required for creating SRV record.
 * `port` - (Optional) The port for an SRV Record. Port is required for creating SRV record.
 * `caa_type` - (Optional) The type for an CAA Record. Caatype is required for creating CAA record. Caa type can be "issue", "issuewild", "iodef"
-* `issuer_critical` - (Optional) The issuer critical value for an CAA Record. It is required for creating CAA record. Value will be integer less than or equla to 255.
+* `issuer_critical` - (Optional) The issuer critical value for an CAA Record. It is required for creating CAA record. Value will be integer less than or equal to 255.
 
-## Attribute Reference ##
-The only attribute that this resource exports is the `domain_id`, which is set to the dme calculated id of the resource.
+## Import
+
+The Dns Record can be imported using the domain_id and the dns record's id:
+
+```
+terraform import dme_dns_record.example domain_id:dns_record_id
+```

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -33,18 +33,30 @@ resource "dme_dns_record" "record" {
 * `name` - (Required) Name of record.
 * `domain_id` - (Required) The DME Domain Id the record should be created under.
 * `value` - (Required) Value of the record.
-  * For `A` record Ipv4 address is required. For example: value: "1.2.3.4"
-  * For `CNAME` record alias name is required. For example: value: "www"
-  * For `ANAME` record FQDN is required. For example: value: "www.google.com."
-  * For `MX` record server name is required. For example: value: "document."
-  * For `HTTPRED` record URL is required. For example: value: "http://www.google.com"
-  * For `TXT` record text data is required. For example: value: "practice"
-  * For `SPF` record string value is required. For example: value: "1.2.3.4"
-  * For `PTR` record host name is required. For example: value: "mail.domainDocument."
-  * For `NS` record host name is required. For example: value: "mail.domainDocument." 
-  * For `AAAA` record IPv6 address is required. For example: value: "0::0:0:0:0:0:6"
-  * For `SRV` record host name is required. For example: value: "mail.domainDocument."
-  * For `CAA` record text data is required. For example: value: "comodoca.com"
+  For `A` record Ipv4 address is required. For example: value: "1.2.3.4"
+  
+  For `CNAME` record alias name is required. For example: value: "www"
+  
+  For `ANAME` record FQDN is required. For example: value: "www.google.com."
+  
+  For `MX` record server name is required. For example: value: "document."
+  
+  For `HTTPRED` record URL is required. For example: value: "http://www.google.com"
+  
+  For `TXT` record text data is required. For example: value: "practice"
+  
+  For `SPF` record string value is required. For example: value: "1.2.3.4"
+  
+  For `PTR` record host name is required. For example: value: "mail.domainDocument."
+  
+  For `NS` record host name is required. For example: value: "mail.domainDocument." 
+  
+  For `AAAA` record IPv6 address is required. For example: value: "0::0:0:0:0:0:6"
+  
+  For `SRV` record host name is required. For example: value: "mail.domainDocument."
+  
+  For `CAA` record text data is required. For example: value: "comodoca.com"
+  
 * `type` - (Required) The record type. Possible Values: `A`, `AAAA`, `ANAME`, `CNAME`, `HTTPRED`, `MX`, `NS`, `PTR`, `SRV`, `TXT`, `CAA` or `SPF`.
 * `ttl` - (Required) The time to live or TTL of the record.
 * `gtd_location` - (Optional) Global Traffic Director location. Values:DEFAULT, US_EAST, US_WEST, EUROPE, ASIA_PAC, OCREANIA.


### PR DESCRIPTION
## Description

Attempt at setting up dme_dns_record to support import.

The record must be imported using `domain_id:dns_record_id` since an API call needs to be made to do the import, it does not seem possible to reference existing TF configuration to obtain this. 

Also, there is not a way to query for a dns_record_id directly documented in the API that i found. So we get all records for the domain via https://api-docs.dnsmadeeasy.com/#ae20deac-3681-48fd-a8ee-aca15d0edafd and sift through the Ids there. 

Tested on the sandbox using the config in the root of this repo in main.tf.

Fixes #48

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] CI/CD changes

## How Has This Been Tested?

I've added a test but unsure how robust the testing for import is. In the dme folder, running go test passes:

```
❯ go test   
PASS
ok      github.com/terraform-providers/terraform-provider-dme/dme       0.273s
```

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Performance testing
- [ ] Security testing

**Test Environment:**
- OS: MacOs 14
- Version: Terraform v1.9.0
on darwin_arm64
- Dependencies: `go version go1.24.6 darwin/arm64`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have read and followed the [Code of Conduct](CODE_OF_CONDUCT.md) (there is none?)

## Additional Notes

This is my first work on a terraform provider.

As noted in another issue/PR, this uses the old SDK and probably would benefit in using the modern terraform-plugin-framework.

## Related Issues

- Closes #48

## Breaking Changes

n/a

## Performance Impact

 Seems like would be more efficient if we could query the API for a dns record's ID.

## Security Considerations


---

**Note:** Please ensure that your pull request follows our [Contributing Guidelines](https://github.com/DNSMadeEasy/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/DNSMadeEasy/.github/blob/main/CODE_OF_CONDUCT.md).
